### PR TITLE
Create `/inscription-data/:inscription_id` endpoint for integrity check

### DIFF
--- a/src/index/updater/inscription_updater.rs
+++ b/src/index/updater/inscription_updater.rs
@@ -196,7 +196,6 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
     new_satpoint: SatPoint,
   ) -> Result {
     let inscription_id = flotsam.inscription_id.store();
-    let inscription_number = self.next_number;
 
     match flotsam.origin {
       Origin::Old(old_satpoint) => {
@@ -245,6 +244,8 @@ impl<'a, 'db, 'tx> InscriptionUpdater<'a, 'db, 'tx> {
 
     let inscription_id = InscriptionId::load(inscription_id);
     let satpoint = SatPoint::load(new_satpoint);
+    let inscription_entry = self.id_to_entry.get(&inscription_id.store())?.unwrap();
+    let inscription_number = InscriptionEntry::load(inscription_entry.value()).number;
 
     if let Some(tx_in) = flotsam.tx_in {
       let inscription = Inscription::from_tx_input(&tx_in).unwrap();

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -89,6 +89,7 @@ impl Display for StaticHtml {
 
 #[derive(Serialize, Deserialize)]
 struct InscriptionData {
+  number: u64,
   id: InscriptionId,
   owner_address: Address,
   location: SatPoint,
@@ -874,6 +875,7 @@ impl Server {
       .unwrap();
 
     let insc = InscriptionData {
+      number: entry.number,
       id: inscription_id,
       owner_address,
       genesis_height: entry.height,

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -854,13 +854,22 @@ impl Server {
       .nth(satpoint.outpoint.vout.try_into().unwrap())
       .ok_or_not_found(|| format!("inscription {inscription_id} current transaction output"))?;
 
-    let creation_output = index
+    let previous_outpoint = index
       .get_transaction(inscription_id.txid)?
+      .ok_or_not_found(|| format!("inscription {inscription_id} current transaction"))?
+      .input
+      .into_iter()
+      .nth(inscription_id.index.try_into().unwrap())
+      .ok_or_not_found(|| format!("inscription {inscription_id} creation transaction output"))?
+      .previous_output;
+
+    let previous_output = index
+      .get_transaction(previous_outpoint.txid)?
       .ok_or_not_found(|| format!("inscription {inscription_id} current transaction"))?
       .output
       .into_iter()
-      .nth(satpoint.outpoint.vout.try_into().unwrap())
-      .ok_or_not_found(|| format!("inscription {inscription_id} creation transaction output"))?;
+      .nth(previous_outpoint.vout.try_into().unwrap())
+      .ok_or_not_found(|| format!("inscription {inscription_id} current transaction output"))?;
 
     let owner_address = config
       .chain
@@ -870,7 +879,7 @@ impl Server {
 
     let creator_address = config
       .chain
-      .address_from_script(&creation_output.script_pubkey)
+      .address_from_script(&previous_output.script_pubkey)
       .ok()
       .unwrap();
 

--- a/src/subcommand/server.rs
+++ b/src/subcommand/server.rs
@@ -17,7 +17,7 @@ use {
     http::{header, HeaderMap, HeaderValue, StatusCode, Uri},
     response::{IntoResponse, Redirect, Response},
     routing::get,
-    Router, TypedHeader, Json,
+    Json, Router, TypedHeader,
   },
   axum_server::Handle,
   rust_embed::RustEmbed,
@@ -88,7 +88,7 @@ impl Display for StaticHtml {
 }
 
 #[derive(Serialize, Deserialize)]
-struct InscriptionData{
+struct InscriptionData {
   id: InscriptionId,
   owner_address: Address,
   location: SatPoint,
@@ -166,7 +166,10 @@ impl Server {
         .route("/feed.xml", get(Self::feed))
         .route("/input/:block/:transaction/:input", get(Self::input))
         .route("/inscription/:inscription_id", get(Self::inscription))
-        .route("/inscription-data/:inscription_id", get(Self::inscription_data))
+        .route(
+          "/inscription-data/:inscription_id",
+          get(Self::inscription_data),
+        )
         .route("/inscriptions", get(Self::inscriptions))
         .route("/inscriptions/:from", get(Self::inscriptions_from))
         .route("/install.sh", get(Self::install_script))
@@ -828,7 +831,7 @@ impl Server {
   async fn inscription_data(
     Extension(config): Extension<Arc<PageConfig>>,
     Extension(index): Extension<Arc<Index>>,
-    Path(DeserializeFromStr(inscription_id)): Path<DeserializeFromStr<InscriptionId>>
+    Path(DeserializeFromStr(inscription_id)): Path<DeserializeFromStr<InscriptionId>>,
   ) -> ServerResult<Json<InscriptionData>> {
     let entry = index
       .get_inscription_entry(inscription_id)?
@@ -858,11 +861,17 @@ impl Server {
       .nth(satpoint.outpoint.vout.try_into().unwrap())
       .ok_or_not_found(|| format!("inscription {inscription_id} creation transaction output"))?;
 
-    let owner_address = config.chain
-      .address_from_script(&output.script_pubkey).ok().unwrap();
+    let owner_address = config
+      .chain
+      .address_from_script(&output.script_pubkey)
+      .ok()
+      .unwrap();
 
-    let creator_address = config.chain
-      .address_from_script(&creation_output.script_pubkey).ok().unwrap();
+    let creator_address = config
+      .chain
+      .address_from_script(&creation_output.script_pubkey)
+      .ok()
+      .unwrap();
 
     let insc = InscriptionData {
       id: inscription_id,


### PR DESCRIPTION
example:
`http://localhost/inscription-data/87f658f9d019b95bc8c5903eef5e9e1587ca703c95d4f74d5451230cfc5ea806i0`

```json
{
  "number": 2929,
  "id": "87f658f9d019b95bc8c5903eef5e9e1587ca703c95d4f74d5451230cfc5ea806i0",
  "owner_address": "tb1pwzv7fv35yl7ypwj8w7al2t8apd6yf4568cs772qjwper74xqc99sk8x7tk",
  "location": "d059538045a4b5a0faf70cc2faf60473feb2a4468afa95c1d04282f20f356416:0:5000007420",
  "genesis_height": 136972,
  "genesis_transaction": "87f658f9d019b95bc8c5903eef5e9e1587ca703c95d4f74d5451230cfc5ea806",
  "creator_address": "tb1pqs3p6td6jqlhqtpmernpdhn50fhkn3k6kxwssl862hdv2t0gtdcs6dtjpn",
  "content_length": 8,
  "content_type": "text/plain;charset=utf-8"
}
```