### PR TITLE
Add `pubkey` on `ord wallet create` cmd

### DIFF
--- a/src/subcommand/wallet/create.rs
+++ b/src/subcommand/wallet/create.rs
@@ -31,7 +31,7 @@ impl Create {
     let mnemonic = Mnemonic::from_entropy(&entropy)?;
     let seed = mnemonic.to_seed(self.passphrase.clone());
     let secp = Secp256k1::new();
-    let root = bip32::ExtendedPrivKey::new_master(Network::Testnet, &seed)?;
+    let root = bip32::ExtendedPrivKey::new_master(options.chain().network(), &seed)?;
 
     let xprv = root.derive_priv(&secp, &DerivationPath::from_str("m/86'/1'/0'")?)?;
     let xpub = ExtendedPubKey::from_priv(&secp, &xprv);

--- a/src/subcommand/wallet/create.rs
+++ b/src/subcommand/wallet/create.rs
@@ -1,8 +1,15 @@
+use bitcoin::{
+  secp256k1::PublicKey,
+  util::bip32::{self, ExtendedPubKey},
+};
+
 use super::*;
 
 #[derive(Serialize)]
 struct Output {
   mnemonic: Mnemonic,
+  address: Address,
+  public_key: PublicKey,
   passphrase: Option<String>,
 }
 
@@ -22,11 +29,26 @@ impl Create {
     rand::thread_rng().fill_bytes(&mut entropy);
 
     let mnemonic = Mnemonic::from_entropy(&entropy)?;
+    let seed = mnemonic.to_seed(self.passphrase.clone());
+    let secp = Secp256k1::new();
+    let root = bip32::ExtendedPrivKey::new_master(Network::Testnet, &seed)?;
+
+    let xprv = root.derive_priv(&secp, &DerivationPath::from_str("m/86'/1'/0'")?)?;
+    let xpub = ExtendedPubKey::from_priv(&secp, &xprv);
+    let public_key = xpub
+      .derive_pub(&secp, &DerivationPath::from_str("m/0/0")?)?
+      .public_key;
 
     initialize_wallet(&options, mnemonic.to_seed(self.passphrase.clone()))?;
 
+    let address = options
+      .bitcoin_rpc_client_for_wallet_command(false)?
+      .get_new_address(None, Some(bitcoincore_rpc::json::AddressType::Bech32m))?;
+
     print_json(Output {
       mnemonic,
+      address,
+      public_key,
       passphrase: Some(self.passphrase),
     })?;
 


### PR DESCRIPTION
```
ord wallet create
```

```json
{
  "mnemonic": "blade afraid month fragile decorate genuine baby wink sibling useless fire setup",
  "address": "tb1psx20z0a6vu227gsw9jfudlg444ttd6ajtnjtq7ws6f09lz8xeltsxuk25a",
  "public_key": "03e43b161143c532054d4790ad0c8f1fe561935964a557161120864d40a7d15a07",
  "passphrase": ""
}
```

`address` / `public_key` are the first to be derived from the created wallet.