### PR TITLE
Fix rpc_url function to add wallet to url

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -82,13 +82,14 @@ impl Options {
   }
 
   pub(crate) fn rpc_url(&self) -> String {
-    self.rpc_url.clone().unwrap_or_else(|| {
+    let url = self.rpc_url.clone().unwrap_or_else(|| {
       format!(
-        "127.0.0.1:{}/wallet/{}",
-        self.chain().default_rpc_port(),
-        self.wallet
+        "127.0.0.1:{}",
+        self.chain().default_rpc_port()
       )
-    })
+    });
+
+    format!("{}/wallet/{}", url, self.wallet)
   }
 
   pub(crate) fn cookie_file(&self) -> Result<PathBuf> {


### PR DESCRIPTION
## Bug
If we pass `--rpc-url 127.0.0.1:38332` to the ord command, it doesn't add the wallet at the end and it uses the URL exactly how we set, otherwise, it generates the rpc_url with the wallet as follows:
```rust
format!("127.0.0.1:{}/wallet/{}",self.chain().default_rpc_port(),self.wallet)
```

## Solution
Now it adds the wallet at the end of the RPC URL, no matter if the RPC URL is from `--rpc-url` or not.